### PR TITLE
feat(WF): PDF 1.3; Strider `Swap Kit` lcp rework

### DIFF
--- a/Wallflower Rebakes/lcp_manifest.json
+++ b/Wallflower Rebakes/lcp_manifest.json
@@ -3,7 +3,7 @@
   "author": "Kai Tave, LCP by Stebb, SkydivingSnake, Eleonor, Tetra and Kukri",
   "description": "NPC data for Kai Tave's No Room for a Wallflower NPC Rebake.",
   "item_prefix": "nrfaw-npc-rebake",
-  "version": "1.3.5",
+  "version": "2.1.0",
   "image_url": "",
   "website": "",
   "dependencies": [

--- a/Wallflower Rebakes/npc_classes.json
+++ b/Wallflower Rebakes/npc_classes.json
@@ -400,6 +400,7 @@
             "nrfaw-npc-rebake_npcf_swap_kit_strider",
             "nrfaw-npc-rebake_npcf_marksman_kit_strider",
             "nrfaw-npc-rebake_npcf_skirmisher_kit_strider",
+            "nrfaw-npc-rebake_npcf_marksman_kit_ranger_long_rifle_strider",
             "nrfaw-npc-rebake_npcf_marksman_kit_flash_grenade_strider",
             "nrfaw-npc-rebake_npcf_marksman_kit_adaptive_camouflage_strider",
             "nrfaw-npc-rebake_npcf_skirmisher_kit_explosive_carbine_strider",

--- a/Wallflower Rebakes/npc_classes.json
+++ b/Wallflower Rebakes/npc_classes.json
@@ -38,9 +38,9 @@
                 5
             ],
             "sensor": [
-                10,
-                10,
-                10
+                8,
+                8,
+                8
             ],
             "save": [
                 10,
@@ -335,9 +335,9 @@
                 14
             ],
             "edef": [
-                8,
                 10,
-                12
+                12,
+                14
             ],
             "heatcap": [
                 7,
@@ -398,8 +398,8 @@
         },
         "base_features": [
             "nrfaw-npc-rebake_npcf_swap_kit_strider",
-            "nrfaw-npc-rebake_npcf_kit_bonus_strider",
-            "nrfaw-npc-rebake_npcf_marksman_kit_ranger_long_rifle_strider",
+            "nrfaw-npc-rebake_npcf_marksman_kit_strider",
+            "nrfaw-npc-rebake_npcf_skirmisher_kit_strider",
             "nrfaw-npc-rebake_npcf_marksman_kit_flash_grenade_strider",
             "nrfaw-npc-rebake_npcf_marksman_kit_adaptive_camouflage_strider",
             "nrfaw-npc-rebake_npcf_skirmisher_kit_explosive_carbine_strider",

--- a/Wallflower Rebakes/npc_features.json
+++ b/Wallflower Rebakes/npc_features.json
@@ -392,7 +392,7 @@
     },
     "locked": false,
     "type": "Tech",
-    "effect": "The Spite chooses a character within <strong>Sensors</strong> and infects them with a catalyzing virus. Characters infected by this virus take <strong>1 heat</strong> at the start of their turn, plus <strong>1 additional heat</strong> for each successive turn they remain infected beyond the first up to a maximum of <strong>3 heat</strong> per turn, and cannot clear <strong>heat</strong> by any means except for overheating. This effect lasts for the rest of the scene, until the Spite is destroyed, until the Spite uses this system on a different character, or until the infected character moves adjacent to (or begins their turn adjacent to) the Spite.",
+    "effect": "The Spite chooses a character within <strong>Sensors</strong> and infects them with a catalyzing virus. Characters infected by this virus take <strong>1 heat</strong> at the start of their turn and cannot clear <strong>heat</strong> by any means except for overheating. This effect lasts for the rest of the scene, until the Spite is destroyed, until the Spite uses this system on a different character, or until the infected character moves adjacent to (or begins their turn adjacent to) the Spite.",
     "tags": [
       {
         "id": "tg_full_tech"
@@ -543,7 +543,7 @@
     },
     "locked": false,
     "type": "Trait",
-    "effect": "The Strider has two kits consisting of unique weapons, systems, and traits, the <strong>Marksman Kit</strong> and <strong>Skirmisher Kit</strong>. Each kit comes with a special <strong>Kit Bonus</strong> that activates at the start of their turn, as well as a <strong>Swap Bonus</strong> that only activates when they use this trait to swap to that kit; if the Strider chooses to gain the <strong>Kit Bonus</strong>, then they can't activate this trait (and thus gain the <strong>Swap Bonus</strong>) until the start of their next turn. When one of the Strider's weapons or systems are destroyed, it must be chosen from their active kit.<p><strong>Marksman Kit Swap Bonus</strong>: This turn only, the <strong>Ranger Long Rifle</strong> ignores the <strong>Ordnance</strong> tag.</p><p><strong>Skirmisher Kit Swap Bonus</strong>: The Strider makes an attack against a character of their choice within <strong>Range 5</strong> using the <strong>Explosive Carbine</strong> as a <strong>free action</strong>.</p>",
+    "effect": "<p>The Strider has two kits consisting of unique weapons, systems, and traits, the <strong>Marksman Kit</strong> and <strong>Skirmisher Kit</strong>. Each kit comes with a special <strong>Kit Bonus</strong> that activates at the start of their turn, as well as a <strong>Swap Bonus</strong> that only activates when they use this trait to swap to that kit; if the Strider chooses to gain the <strong>Kit Bonus</strong>, then they can't activate this trait (and thus gain the <strong>Swap Bonus</strong>) until the start of their next turn. When one of the Strider's weapons or systems are destroyed, it must be chosen from their active kit.</p><p>The Strider may choose either kit to begin combat in.</p>",
     "tags": [
       {
         "id": "tg_quick_action"
@@ -551,8 +551,8 @@
     ]
   },
   {
-    "id": "nrfaw-npc-rebake_npcf_kit_bonus_strider",
-    "name": "Kit Bonus",
+    "id": "nrfaw-npc-rebake_npcf_marksman_kit_strider",
+    "name": "Marksman Kit",
     "origin": {
       "type": "Class",
       "name": "STRIDER",
@@ -560,7 +560,24 @@
     },
     "locked": false,
     "type": "Trait",
-    "effect": "<p><strong>Marksman Kit Bonus</strong>: As a <strong>protocol</strong>, the Strider may <strong>Lock On</strong> to a hostile character within <strong>Sensors</strong> and line of sight.</p><p><strong>Skirmisher Kit Bonus</strong>: As a <strong>protocol</strong>, the Strider may move <strong>2 spaces</strong>. This movement ignores engagement and doesn't provoke <strong>reactions</strong>.</p>",
+    "effect": "<p> The <strong>Marksman Kit</strong> is composed of: <ul> <li><strong>Ranger Long Rifle</strong></li> <li><strong>Flash Grenade</strong></li> <li><strong>Adaptive Camouflage</strong></li> </ul> </p><p><strong>Marksman Kit Bonus</strong>: As a <strong>protocol</strong>, the Strider may <strong>Lock On</strong> to a hostile character within <strong>Sensors</strong> and line of sight.</p><p><strong>Marksman Kit Swap Bonus</strong>: This turn only, the <strong>Ranger Long Rifle</strong> ignores the <strong>Ordnance</strong> tag.</p>",
+    "tags": [
+      {
+        "id": "tg_protocol"
+      }
+    ]
+  },
+  {
+    "id": "nrfaw-npc-rebake_npcf_skirmisher_kit_strider",
+    "name": "Skirmisher Kit",
+    "origin": {
+      "type": "Class",
+      "name": "STRIDER",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "<p> The <strong>Skirmisher Kit</strong> is composed of: <ul> <li><strong>Explosive Carbine</strong></li> <li><strong>Reposition</strong></li> <li><strong>Smoke Grenade</strong></li> </ul> </p> <p> <strong>Skirmisher Kit Bonus</strong>: As a <strong>protocol</strong>, the Strider may move <strong>2 spaces</strong>. This movement ignores engagement and doesn't provoke <strong>reactions</strong>. </p> <p> <strong>Skirmisher Kit Swap Bonus</strong>: The Strider makes an attack against a character of their choice within <strong>Range 5</strong> using the <strong>Explosive Carbine</strong> as a <strong>free action</strong>. </p>",
     "tags": [
       {
         "id": "tg_protocol"
@@ -585,9 +602,9 @@
     ],
     "weapon_type": "Heavy Rifle",
     "attack_bonus": [
-      0,
       1,
-      2
+      2,
+      3
     ],
     "accuracy": [
       0,
@@ -854,7 +871,7 @@
     },
     "locked": false,
     "type": "Trait",
-    "effect": "Before combat begins, the Avenger chooses an allied <strong>non-Grunt, non-Drone</strong> character; the Avenger and the chosen character are <strong>bondmates</strong>. During the Avenger's turn, as a <strong>protocol</strong> they may move their <strong>Speed</strong> towards their bondmate, or their bondmate may move their <strong>Speed</strong> towards them, as directly as possible. When the Avenger's bondmate is destroyed while within <strong>Range 5</strong> of the Avenger, they instead survive with <strong>1 HP</strong>; this still activates <strong>Revenge</strong>. A character can only have one bondmate this way.",
+    "effect": "Before combat begins, the Avenger chooses an allied <strong>non-Grunt, non-Drone</strong> character; the Avenger and the chosen character are <strong>bondmates</strong>. During the Avenger's turn, as a <strong>protocol</strong> they may move their <strong>Speed</strong> towards their bondmate, or their bondmate may move their <strong>Speed</strong> towards them, as directly as possible. When the Avenger's bondmate is destroyed while within <strong>Range 5</strong> of the Avenger, they instead survive with <strong>1 HP</strong>; this still activates <strong>Revenge</strong>. This effect can only activate once, and a character can only have one bondmate this way.",
     "tags": []
   },
   {

--- a/Wallflower Rebakes/npc_templates.json
+++ b/Wallflower Rebakes/npc_templates.json
@@ -1,14 +1,14 @@
 [
-    {"id": "nrfaw-npc-rebake_npct_veteran",
+    {
+        "id": "nrfaw-npc-rebake_npct_veteran",
         "name": "NRFaWF Veteran [K]",
         "description": "<p>Veterans are hardened, experienced fighters that have survived several direct engagements. This isn’t their first rodeo, and their ability to withstand morale shocks is far higher than an untested greenhorn. Their value on the field is the experience they bring to a deployment and their steady presence along the line.</p><p>Use the Veteran template to make more memorable characters.</p>",
-        "base_features": [
-     ],
-     "optional_features": [
-        "nrfaw-npc-rebake_npcf_solidarity_veteran",
-        "nrfaw-npc-rebake_npcf_seeded_shadows_veteran",
-        "nrfaw-npc-rebake_npcf_rebuke_veteran",
-        "nrfaw-npc-rebake_npcf_ranger_training_veteran"
+        "base_features": [],
+        "optional_features": [
+            "nrfaw-npc-rebake_npcf_solidarity_veteran",
+            "nrfaw-npc-rebake_npcf_seeded_shadows_veteran",
+            "nrfaw-npc-rebake_npcf_rebuke_veteran",
+            "nrfaw-npc-rebake_npcf_ranger_training_veteran"
         ]
     }
 ]


### PR DESCRIPTION
# Description

Update LCP with PDFv1.3 content. Also reworks how `Swap Kit` is represented in the LCP beyond what the PDF portrays. For the sake of VTT organization, `Swap Kit`, `Marksman Kit`, and `Skirmisher Kit` are 3 different traits. The first describes the rules of swapping, then the other two describe their `Kit Bonus` and `Swap Bonus` along with the equipment associated with each kit.

## Type of Change

Delete irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
